### PR TITLE
chore: remove go 1.17 compat from go mod calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,26 @@ This CHANGELOG is a format conforming to [keep-a-changelog](https://github.com/o
 It is generated with git-chglog -o CHANGELOG.md
 
 
+<a name="v0.2.1"></a>
+## [v0.2.1](https://github.com/CestusIO/fabricator-generate-plugin-go/compare/v0.2.0...v0.2.1)
+
+### Chores
+
+* remove go 1.17 compat from go mod calls * enough time should have passed for this to now work
+
+
+<a name="v0.2.0"></a>
+## [v0.2.0](https://github.com/CestusIO/fabricator-generate-plugin-go/compare/v0.0.2...v0.2.0)
+
+### Bug Fixes
+
+* rereleasing 0.0.2 as 0.2.0
+
+
 <a name="v0.0.2"></a>
 ## [v0.0.2](https://github.com/CestusIO/fabricator-generate-plugin-go/compare/v0.1.0...v0.0.2)
 
-### Feat
+### Features
 
 * move to github
 
@@ -16,7 +32,7 @@ It is generated with git-chglog -o CHANGELOG.md
 <a name="v0.1.0"></a>
 ## v0.1.0
 
-### Feat
+### Features
 
 * add version.go generation
 * use code.cestus.io/libs/buildinfo

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -162,5 +162,5 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/fabricator-generate-plugin-go/implement.go
+++ b/pkg/fabricator-generate-plugin-go/implement.go
@@ -111,7 +111,7 @@ func (p *plugin) Generate(ctx context.Context, io fabricator.IOStreams, patterns
 			return fmt.Errorf("failed to run template generation commands for project: %s", err)
 		}
 	}
-	if err = executor.Run(ctx, "go", "mod", "tidy", "-compat=1.17"); err != nil {
+	if err = executor.Run(ctx, "go", "mod", "tidy" /*, "-compat=1.17"*/); err != nil {
 		fmt.Fprintf(io.Out, "go mod tidy failed: %s\n", err.Error())
 	}
 	// format files first so we dont run into generation failures

--- a/pkg/fabricator-generate-plugin-go/templates/fabricator-generate-plugin-go/go/pkg/PLUGINNAME/implement.go.template
+++ b/pkg/fabricator-generate-plugin-go/templates/fabricator-generate-plugin-go/go/pkg/PLUGINNAME/implement.go.template
@@ -116,7 +116,7 @@ func (p *plugin) Generate(ctx context.Context, io fabricator.IOStreams, patterns
 			return fmt.Errorf("failed to run template generation commands for project: %s", err)
 		}
 	}
-	if err = executor.Run(ctx, "go", "mod", "tidy", "-compat=1.17"); err != nil {
+	if err = executor.Run(ctx, "go", "mod", "tidy"/*, "-compat=1.17"*/); err != nil {
 		fmt.Fprintf(io.Out, "go mod tidy failed: %s\n", err.Error())
 	}
 	// format files first so we dont run into generation failures

--- a/version.yml
+++ b/version.yml
@@ -1,2 +1,2 @@
-current: 0.2.0
-next: 0.2.0
+current: 0.2.1
+next: 0.2.1


### PR DESCRIPTION
* enough time should have passed for this to now work